### PR TITLE
Protobuf python install script not executed

### DIFF
--- a/cmake/External_Protobuf.cmake
+++ b/cmake/External_Protobuf.cmake
@@ -82,7 +82,7 @@ function(yoda_external_package)
   ExternalProject_Add_Step(
     protobuf python-build
     COMMAND ${BASH_EXECUTABLE} ${install_script}
-    DEPENDEES build
+    DEPENDEES build install
   )
   ExternalProject_Add_Step(
     protobuf post-build


### PR DESCRIPTION
The order of execution of steps is still incorrect. `python-build` doesn't get executed unless `install` depends on it. This PR aims at fixing this issue.